### PR TITLE
AM_MIDI2.0Lib link fix

### DIFF
--- a/UUT/CME_WIDI_CORE_EXP/CMakeLists.txt
+++ b/UUT/CME_WIDI_CORE_EXP/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(UUT_CME_WIDI_CORE
         hardware_spi
         hardware_flash
         hardware_dma
-        midi2
+        libmidi2
 )
 
 # pico_enable_stdio_usb(ProtoZOA_UUT 1)

--- a/UUT/DIN_Bridge/CMakeLists.txt
+++ b/UUT/DIN_Bridge/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(UUT_DIN_BRIDGE
         hardware_spi
         hardware_flash
         hardware_dma
-        midi2
+        libmidi2
 )
 
 # pico_enable_stdio_usb(ProtoZOA_UUT 1)

--- a/UUT/USB_FunctionBlocks/CMakeLists.txt
+++ b/UUT/USB_FunctionBlocks/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(UUT_USB_FB
         hardware_spi
         hardware_flash
         hardware_dma
-        midi2
+        libmidi2
 )
 
 

--- a/UUT_FreeRTOS/FreeRTOS_Tasks/CMakeLists.txt
+++ b/UUT_FreeRTOS/FreeRTOS_Tasks/CMakeLists.txt
@@ -89,7 +89,6 @@ target_include_directories(UUT_FREERTOS_TASKS PUBLIC
         ../../Common
         ../../Common/include
         ../../lib/tusb_ump
-        ../../lib/AM_MIDI2.0Lib
         )
 
 pico_generate_pio_header(UUT_FREERTOS_TASKS ${CMAKE_CURRENT_LIST_DIR}/../../Common/pio_serial/uart_rx.pio)
@@ -111,7 +110,6 @@ target_link_libraries(UUT_FREERTOS_TASKS
         hardware_dma
         FreeRTOS-Kernel
         FreeRTOS-Kernel-Heap1
-        midi2
         ni-midi2
 )
 

--- a/UUT_FreeRTOS/USB_MIDI_Echo/CMakeLists.txt
+++ b/UUT_FreeRTOS/USB_MIDI_Echo/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(UUT_USB_MIDI_ECHO
         hardware_dma
         FreeRTOS-Kernel
         FreeRTOS-Kernel-Heap1
-        midi2
+        libmidi2
 )
 
 # pico_enable_stdio_usb(ProtoZOA_UUT 1)


### PR DESCRIPTION
AMMIDI2.0Lib library name is now `libmidi2`, no longer `midi2`.