### PR TITLE
fix MIDI-CI Discovery not returning associated Function Block

### DIFF
--- a/UUT_FreeRTOS/FreeRTOS_Tasks/UMPProcessing.cpp
+++ b/UUT_FreeRTOS/FreeRTOS_Tasks/UMPProcessing.cpp
@@ -384,7 +384,7 @@ void UMPProcessing::processMIDICIMessage(const midi::capability_inquiry_view& ms
         {
             printf("sendSysex(make_discovery_reply)\n");
             sendSysex(make_discovery_reply(
-                m_muid, di->source_muid(), my_identity, category::property_exchange, maxSysexMessageSize, di->output_path_id()));
+                m_muid, di->source_muid(), my_identity, category::property_exchange, maxSysexMessageSize, di->output_path_id(), 0));
         
             return;
         }


### PR DESCRIPTION
macOS Sequoia new MIDI API testing revealed a bug in the `UUT_FreeRTOS_Tasks` firmware:

* MIDI-CI Discovery does return `0x7F` as function block, has to be `0`
 